### PR TITLE
Make slider show length of meeting as time, expand up to 12 steps

### DIFF
--- a/calendar/schedulemeeting.kv
+++ b/calendar/schedulemeeting.kv
@@ -74,12 +74,12 @@
         size_hint: [.7, .08]
         id: slider_meeting_length
         min: 0
-        max: 8
+        max: 12
         step: 1
         orientation: 'horizontal'
     Label:
         size_hint: [.1, .08]
-        text: str(slider_meeting_length.value)
+        text: str(schedulemeeting.TD_15MIN * slider_meeting_length.value)
 
     # Meeting times
     ScheduleLabel:

--- a/calendar/schedulemeeting.py
+++ b/calendar/schedulemeeting.py
@@ -18,9 +18,13 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
+from datetime import timedelta
 
 from kivy.uix.stacklayout import StackLayout
 from email.utils import parseaddr
+
+TD_15MIN = timedelta(minutes=15)
+
 
 class ScheduleMeeting(StackLayout):
 


### PR DESCRIPTION
Addresses Issue #10 and expands number of steps on slider to 12 (0:00:0-3:00:00 in steps of 15 minutes)